### PR TITLE
Updated to latest version, reduced clone

### DIFF
--- a/token-tracker/Cargo.toml
+++ b/token-tracker/Cargo.toml
@@ -8,21 +8,22 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
-[target.wasm32-unknown-unknown.dependencies]
+[dependencies]
 ethabi = "17.0"
 hex-literal = "0.3.4"
 prost = "0.11.0"
 # Use latest from https://crates.io/crates/substreams
-substreams = "0.0.21"
+substreams = "0.4.0"
 # Use latest from https://crates.io/crates/substreams-ethereum
-substreams-ethereum = "0.2.2-rc.2"
+substreams-ethereum = "0.7.0"
 
+[target.wasm32-unknown-unknown.dependencies]
 # Required so that ethabi > ethereum-types build correctly under wasm32-unknown-unknown
 getrandom = { version = "0.2", features = ["custom"] }
 
 [build-dependencies]
 anyhow = "1"
-substreams-ethereum = "0.2.2-rc.2"
+substreams-ethereum = "0.7.0"
 
 [profile.release]
 lto = true

--- a/token-tracker/rust-toolchain.toml
+++ b/token-tracker/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.64.0"
+components = [ "rustfmt" ]
+targets = [ "wasm32-unknown-unknown" ]

--- a/token-tracker/src/abi/erc1155.rs
+++ b/token-tracker/src/abi/erc1155.rs
@@ -1,13 +1,12 @@
     const INTERNAL_ERR: &'static str = "`ethabi_derive` internal error";
     /// Contract's functions.
-    #[allow(dead_code)]
-    #[allow(unused_variables)]
+    #[allow(dead_code, unused_imports, unused_variables)]
     pub mod functions {
         use super::INTERNAL_ERR;
         #[derive(Debug, Clone, PartialEq)]
         pub struct BalanceOf {
             pub account: Vec<u8>,
-            pub id: ethabi::Uint,
+            pub id: substreams::scalar::BigInt,
         }
         impl BalanceOf {
             const METHOD_ID: [u8; 4] = [0u8, 253u8, 213u8, 142u8];
@@ -22,7 +21,7 @@
                         &[ethabi::ParamType::Address, ethabi::ParamType::Uint(256usize)],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     account: values
@@ -32,11 +31,16 @@
                         .expect(INTERNAL_ERR)
                         .as_bytes()
                         .to_vec(),
-                    id: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
+                    id: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
                 })
             }
             pub fn encode(&self) -> Vec<u8> {
@@ -45,7 +49,11 @@
                         ethabi::Token::Address(
                             ethabi::Address::from_slice(&self.account),
                         ),
-                        ethabi::Token::Uint(self.id),
+                        ethabi::Token::Uint(
+                            ethabi::Uint::from_big_endian(
+                                self.id.clone().to_signed_bytes_be().as_slice(),
+                            ),
+                        ),
                     ],
                 );
                 let mut encoded = Vec::with_capacity(4 + data.len());
@@ -55,22 +63,25 @@
             }
             pub fn output_call(
                 call: &substreams_ethereum::pb::eth::v2::Call,
-            ) -> Result<ethabi::Uint, String> {
+            ) -> Result<substreams::scalar::BigInt, String> {
                 Self::output(call.return_data.as_ref())
             }
-            pub fn output(data: &[u8]) -> Result<ethabi::Uint, String> {
+            pub fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
                 let mut values = ethabi::decode(
                         &[ethabi::ParamType::Uint(256usize)],
                         data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode output data: {}", e))?;
-                Ok(
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
+                Ok({
+                    let mut v = [0 as u8; 32];
                     values
                         .pop()
                         .expect("one output data should have existed")
                         .into_uint()
-                        .expect(INTERNAL_ERR),
-                )
+                        .expect(INTERNAL_ERR)
+                        .to_big_endian(v.as_mut_slice());
+                    v.into()
+                })
             }
             pub fn match_call(call: &substreams_ethereum::pb::eth::v2::Call) -> bool {
                 match call.input.get(0..4) {
@@ -78,7 +89,7 @@
                     None => false,
                 }
             }
-            pub fn call(&self, address: Vec<u8>) -> Option<ethabi::Uint> {
+            pub fn call(&self, address: Vec<u8>) -> Option<substreams::scalar::BigInt> {
                 use substreams_ethereum::pb::eth::rpc;
                 let rpc_calls = rpc::RpcCalls {
                     calls: vec![
@@ -115,11 +126,20 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
+        }
+        impl substreams_ethereum::rpc::RPCDecodable<substreams::scalar::BigInt>
+        for BalanceOf {
+            fn output(data: &[u8]) -> Result<substreams::scalar::BigInt, String> {
+                Self::output(data)
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct BalanceOfBatch {
             pub accounts: Vec<Vec<u8>>,
-            pub ids: Vec<ethabi::Uint>,
+            pub ids: Vec<substreams::scalar::BigInt>,
         }
         impl BalanceOfBatch {
             const METHOD_ID: [u8; 4] = [78u8, 18u8, 115u8, 244u8];
@@ -141,7 +161,7 @@
                         ],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     accounts: values
@@ -160,7 +180,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                 })
             }
@@ -181,7 +208,11 @@
                             let v = self
                                 .ids
                                 .iter()
-                                .map(|inner| ethabi::Token::Uint(inner.clone()))
+                                .map(|inner| ethabi::Token::Uint(
+                                    ethabi::Uint::from_big_endian(
+                                        inner.clone().to_signed_bytes_be().as_slice(),
+                                    ),
+                                ))
                                 .collect();
                             ethabi::Token::Array(v)
                         },
@@ -194,10 +225,12 @@
             }
             pub fn output_call(
                 call: &substreams_ethereum::pb::eth::v2::Call,
-            ) -> Result<Vec<ethabi::Uint>, String> {
+            ) -> Result<Vec<substreams::scalar::BigInt>, String> {
                 Self::output(call.return_data.as_ref())
             }
-            pub fn output(data: &[u8]) -> Result<Vec<ethabi::Uint>, String> {
+            pub fn output(
+                data: &[u8],
+            ) -> Result<Vec<substreams::scalar::BigInt>, String> {
                 let mut values = ethabi::decode(
                         &[
                             ethabi::ParamType::Array(
@@ -206,7 +239,7 @@
                         ],
                         data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode output data: {}", e))?;
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
                 Ok(
                     values
                         .pop()
@@ -214,7 +247,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                 )
             }
@@ -224,7 +264,10 @@
                     None => false,
                 }
             }
-            pub fn call(&self, address: Vec<u8>) -> Option<Vec<ethabi::Uint>> {
+            pub fn call(
+                &self,
+                address: Vec<u8>,
+            ) -> Option<Vec<substreams::scalar::BigInt>> {
                 use substreams_ethereum::pb::eth::rpc;
                 let rpc_calls = rpc::RpcCalls {
                     calls: vec![
@@ -261,6 +304,15 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
+        }
+        impl substreams_ethereum::rpc::RPCDecodable<Vec<substreams::scalar::BigInt>>
+        for BalanceOfBatch {
+            fn output(data: &[u8]) -> Result<Vec<substreams::scalar::BigInt>, String> {
+                Self::output(data)
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct IsApprovedForAll {
@@ -280,7 +332,7 @@
                         &[ethabi::ParamType::Address, ethabi::ParamType::Address],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     account: values
@@ -325,7 +377,7 @@
                         &[ethabi::ParamType::Bool],
                         data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode output data: {}", e))?;
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
                 Ok(
                     values
                         .pop()
@@ -377,13 +429,21 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
+        }
+        impl substreams_ethereum::rpc::RPCDecodable<bool> for IsApprovedForAll {
+            fn output(data: &[u8]) -> Result<bool, String> {
+                Self::output(data)
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SafeBatchTransferFrom {
             pub from: Vec<u8>,
             pub to: Vec<u8>,
-            pub ids: Vec<ethabi::Uint>,
-            pub amounts: Vec<ethabi::Uint>,
+            pub ids: Vec<substreams::scalar::BigInt>,
+            pub amounts: Vec<substreams::scalar::BigInt>,
             pub data: Vec<u8>,
         }
         impl SafeBatchTransferFrom {
@@ -409,7 +469,7 @@
                         ],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     from: values
@@ -432,7 +492,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                     amounts: values
                         .pop()
@@ -440,7 +507,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                     data: values
                         .pop()
@@ -458,7 +532,11 @@
                             let v = self
                                 .ids
                                 .iter()
-                                .map(|inner| ethabi::Token::Uint(inner.clone()))
+                                .map(|inner| ethabi::Token::Uint(
+                                    ethabi::Uint::from_big_endian(
+                                        inner.clone().to_signed_bytes_be().as_slice(),
+                                    ),
+                                ))
                                 .collect();
                             ethabi::Token::Array(v)
                         },
@@ -466,7 +544,11 @@
                             let v = self
                                 .amounts
                                 .iter()
-                                .map(|inner| ethabi::Token::Uint(inner.clone()))
+                                .map(|inner| ethabi::Token::Uint(
+                                    ethabi::Uint::from_big_endian(
+                                        inner.clone().to_signed_bytes_be().as_slice(),
+                                    ),
+                                ))
                                 .collect();
                             ethabi::Token::Array(v)
                         },
@@ -495,13 +577,16 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SafeTransferFrom {
             pub from: Vec<u8>,
             pub to: Vec<u8>,
-            pub id: ethabi::Uint,
-            pub amount: ethabi::Uint,
+            pub id: substreams::scalar::BigInt,
+            pub amount: substreams::scalar::BigInt,
             pub data: Vec<u8>,
         }
         impl SafeTransferFrom {
@@ -523,7 +608,7 @@
                         ],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     from: values
@@ -540,16 +625,26 @@
                         .expect(INTERNAL_ERR)
                         .as_bytes()
                         .to_vec(),
-                    id: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
-                    amount: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
+                    id: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
+                    amount: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
                     data: values
                         .pop()
                         .expect(INTERNAL_ERR)
@@ -562,8 +657,16 @@
                     &[
                         ethabi::Token::Address(ethabi::Address::from_slice(&self.from)),
                         ethabi::Token::Address(ethabi::Address::from_slice(&self.to)),
-                        ethabi::Token::Uint(self.id),
-                        ethabi::Token::Uint(self.amount),
+                        ethabi::Token::Uint(
+                            ethabi::Uint::from_big_endian(
+                                self.id.clone().to_signed_bytes_be().as_slice(),
+                            ),
+                        ),
+                        ethabi::Token::Uint(
+                            ethabi::Uint::from_big_endian(
+                                self.amount.clone().to_signed_bytes_be().as_slice(),
+                            ),
+                        ),
                         ethabi::Token::Bytes(self.data.clone()),
                     ],
                 );
@@ -589,6 +692,9 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SetApprovalForAll {
@@ -608,7 +714,7 @@
                         &[ethabi::ParamType::Address, ethabi::ParamType::Bool],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     operator: values
@@ -656,6 +762,9 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SupportsInterface {
@@ -674,7 +783,7 @@
                         &[ethabi::ParamType::FixedBytes(4usize)],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     interface_id: {
@@ -708,7 +817,7 @@
                         &[ethabi::ParamType::Bool],
                         data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode output data: {}", e))?;
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
                 Ok(
                     values
                         .pop()
@@ -760,10 +869,18 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
+        }
+        impl substreams_ethereum::rpc::RPCDecodable<bool> for SupportsInterface {
+            fn output(data: &[u8]) -> Result<bool, String> {
+                Self::output(data)
+            }
         }
         #[derive(Debug, Clone, PartialEq)]
         pub struct Uri {
-            pub param0: ethabi::Uint,
+            pub param0: substreams::scalar::BigInt,
         }
         impl Uri {
             const METHOD_ID: [u8; 4] = [14u8, 137u8, 52u8, 28u8];
@@ -778,18 +895,31 @@
                         &[ethabi::ParamType::Uint(256usize)],
                         maybe_data.unwrap(),
                     )
-                    .map_err(|e| format!("unable to decode call.input: {}", e))?;
+                    .map_err(|e| format!("unable to decode call.input: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
-                    param0: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
+                    param0: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
                 })
             }
             pub fn encode(&self) -> Vec<u8> {
-                let data = ethabi::encode(&[ethabi::Token::Uint(self.param0)]);
+                let data = ethabi::encode(
+                    &[
+                        ethabi::Token::Uint(
+                            ethabi::Uint::from_big_endian(
+                                self.param0.clone().to_signed_bytes_be().as_slice(),
+                            ),
+                        ),
+                    ],
+                );
                 let mut encoded = Vec::with_capacity(4 + data.len());
                 encoded.extend(Self::METHOD_ID);
                 encoded.extend(data);
@@ -805,7 +935,7 @@
                         &[ethabi::ParamType::String],
                         data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode output data: {}", e))?;
+                    .map_err(|e| format!("unable to decode output data: {:?}", e))?;
                 Ok(
                     values
                         .pop()
@@ -857,10 +987,18 @@
             ) -> Result<Self, String> {
                 Self::decode(call)
             }
+            fn encode(&self) -> Vec<u8> {
+                self.encode()
+            }
+        }
+        impl substreams_ethereum::rpc::RPCDecodable<String> for Uri {
+            fn output(data: &[u8]) -> Result<String, String> {
+                Self::output(data)
+            }
         }
     }
     /// Contract's events.
-    #[allow(dead_code)]
+    #[allow(dead_code, unused_imports, unused_variables)]
     pub mod events {
         use super::INTERNAL_ERR;
         #[derive(Debug, Clone, PartialEq)]
@@ -921,7 +1059,7 @@
                         &[ethabi::ParamType::Bool],
                         log.data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode log.data: {}", e))?;
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     account: ethabi::decode(
@@ -930,7 +1068,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'account' from topic of type 'address': {}",
+                                "unable to decode param 'account' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -946,7 +1084,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'operator' from topic of type 'address': {}",
+                                "unable to decode param 'operator' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -980,8 +1118,8 @@
             pub operator: Vec<u8>,
             pub from: Vec<u8>,
             pub to: Vec<u8>,
-            pub ids: Vec<ethabi::Uint>,
-            pub values: Vec<ethabi::Uint>,
+            pub ids: Vec<substreams::scalar::BigInt>,
+            pub values: Vec<substreams::scalar::BigInt>,
         }
         impl TransferBatch {
             const TOPIC_ID: [u8; 32] = [
@@ -1042,7 +1180,7 @@
                         ],
                         log.data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode log.data: {}", e))?;
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     operator: ethabi::decode(
@@ -1051,7 +1189,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'operator' from topic of type 'address': {}",
+                                "unable to decode param 'operator' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1067,7 +1205,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'from' from topic of type 'address': {}",
+                                "unable to decode param 'from' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1083,7 +1221,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'to' from topic of type 'address': {}",
+                                "unable to decode param 'to' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1099,7 +1237,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                     values: values
                         .pop()
@@ -1107,7 +1252,14 @@
                         .into_array()
                         .expect(INTERNAL_ERR)
                         .into_iter()
-                        .map(|inner| inner.into_uint().expect(INTERNAL_ERR))
+                        .map(|inner| {
+                            let mut v = [0 as u8; 32];
+                            inner
+                                .into_uint()
+                                .expect(INTERNAL_ERR)
+                                .to_big_endian(v.as_mut_slice());
+                            v.into()
+                        })
                         .collect(),
                 })
             }
@@ -1128,8 +1280,8 @@
             pub operator: Vec<u8>,
             pub from: Vec<u8>,
             pub to: Vec<u8>,
-            pub id: ethabi::Uint,
-            pub value: ethabi::Uint,
+            pub id: substreams::scalar::BigInt,
+            pub value: substreams::scalar::BigInt,
         }
         impl TransferSingle {
             const TOPIC_ID: [u8; 32] = [
@@ -1186,7 +1338,7 @@
                         ],
                         log.data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode log.data: {}", e))?;
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
                     operator: ethabi::decode(
@@ -1195,7 +1347,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'operator' from topic of type 'address': {}",
+                                "unable to decode param 'operator' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1211,7 +1363,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'from' from topic of type 'address': {}",
+                                "unable to decode param 'from' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1227,7 +1379,7 @@
                         )
                         .map_err(|e| {
                             format!(
-                                "unable to decode param 'to' from topic of type 'address': {}",
+                                "unable to decode param 'to' from topic of type 'address': {:?}",
                                 e
                             )
                         })?
@@ -1237,16 +1389,26 @@
                         .expect(INTERNAL_ERR)
                         .as_bytes()
                         .to_vec(),
-                    id: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
-                    value: values
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
+                    id: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
+                    value: {
+                        let mut v = [0 as u8; 32];
+                        values
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
                 })
             }
         }
@@ -1264,7 +1426,7 @@
         #[derive(Debug, Clone, PartialEq)]
         pub struct Uri {
             pub value: String,
-            pub id: ethabi::Uint,
+            pub id: substreams::scalar::BigInt,
         }
         impl Uri {
             const TOPIC_ID: [u8; 32] = [
@@ -1318,23 +1480,28 @@
                         &[ethabi::ParamType::String],
                         log.data.as_ref(),
                     )
-                    .map_err(|e| format!("unable to decode log.data: {}", e))?;
+                    .map_err(|e| format!("unable to decode log.data: {:?}", e))?;
                 values.reverse();
                 Ok(Self {
-                    id: ethabi::decode(
-                            &[ethabi::ParamType::Uint(256usize)],
-                            log.topics[1usize].as_ref(),
-                        )
-                        .map_err(|e| {
-                            format!(
-                                "unable to decode param 'id' from topic of type 'uint256': {}",
-                                e
+                    id: {
+                        let mut v = [0 as u8; 32];
+                        ethabi::decode(
+                                &[ethabi::ParamType::Uint(256usize)],
+                                log.topics[1usize].as_ref(),
                             )
-                        })?
-                        .pop()
-                        .expect(INTERNAL_ERR)
-                        .into_uint()
-                        .expect(INTERNAL_ERR),
+                            .map_err(|e| {
+                                format!(
+                                    "unable to decode param 'id' from topic of type 'uint256': {:?}",
+                                    e
+                                )
+                            })?
+                            .pop()
+                            .expect(INTERNAL_ERR)
+                            .into_uint()
+                            .expect(INTERNAL_ERR)
+                            .to_big_endian(v.as_mut_slice());
+                        v.into()
+                    },
                     value: values
                         .pop()
                         .expect(INTERNAL_ERR)

--- a/token-tracker/src/helper.rs
+++ b/token-tracker/src/helper.rs
@@ -2,34 +2,35 @@ use crate::{
     abi,
     pb::token_tracker::{self},
 };
-use substreams::{log, Hex};
+use hex_literal::hex;
+use substreams::Hex;
 
-// pub const ERC721_IFACE_ID: [u8; 4] = <[u8; 4]>::from_hex("01ffc9a7").unwrap();
-pub const ERC721_IFACE_ID: [u8; 4] = [0x01, 0xff, 0xc9, 0xa7];
+// 0x01ffc9a7
+pub const ERC721_IFACE_ID: [u8; 4] = hex!("01ffc9a7");
 // 0x5b5e139f
-pub const ERC721_METADATA_IFACE_ID: [u8; 4] = [0x5b, 0x5e, 0x13, 0x9f];
+pub const ERC721_METADATA_IFACE_ID: [u8; 4] = hex!("5b5e139f");
 // 0x780e9d63
-pub const ERC721_ENUMERABLE_IFACE_ID: [u8; 4] = [0x78, 0x0e, 0x9d, 0x63];
-// pub const ERC1155_IFACE_ID: [u8; 4] = <[u8; 4]>::from_hex("d9b67a26").unwrap();
-pub const ERC1155_IFACE_ID: [u8; 4] = [0xd9, 0xb6, 0x7a, 0x26];
+pub const ERC721_ENUMERABLE_IFACE_ID: [u8; 4] = hex!("780e9d63");
+// 0xd9b67a26
+pub const ERC1155_IFACE_ID: [u8; 4] = hex!("d9b67a26");
 // 0x0e89341c
-pub const ERC1155_METADATA_URI_IFACE_ID: [u8; 4] = [0x0e, 0x89, 0x34, 0x1c];
+pub const ERC1155_METADATA_URI_IFACE_ID: [u8; 4] = hex!("0e89341c");
 
 // 0x150b7a02
-//pub const ERC721_TOKEN_RECEIVER_IFACE_ID: [u8; 4] = [0x01, 0x50, 0xb7, 0x02];
+//pub const ERC721_TOKEN_RECEIVER_IFACE_ID: [u8; 4] = hex!("0150b702");
 
 pub fn get_token(
-    token_address: String,
-    block_number: String,
-    block_timestamp: String,
-    tx_hash: String,
-    from: String,
+    token_address: &String,
+    block_number: &String,
+    block_timestamp: &String,
+    tx_hash: &String,
+    from: &String,
 ) -> Option<token_tracker::Token> {
     use abi::erc1155::functions as erc1155_functions;
     use abi::erc20::functions as erc20_functions;
     use abi::erc721::functions as erc721_functions;
 
-    let token_address_bytes = Hex::decode(token_address.clone()).unwrap();
+    let token_address_bytes = Hex::decode(token_address).unwrap();
 
     // erc20 call
     let name_res = erc20_functions::Name {}.call(token_address_bytes.clone());
@@ -38,18 +39,19 @@ pub fn get_token(
     let total_supply_res = erc20_functions::TotalSupply {}.call(token_address_bytes.clone());
 
     if let (Some(name), Some(symbol), Some(decimals), Some(total_supply)) =
-        (name_res, symbol_res, decimals_res, total_supply_res) {
+        (name_res, symbol_res, decimals_res, total_supply_res)
+    {
         return Some(token_tracker::Token {
             chain_id: 1.to_string(),
             token_address: token_address.clone(),
             token_type: 1,
-            deployment_transaction_hash: tx_hash,
-            deployment_block: block_number,
-            deployment_timestamp: block_timestamp,
-            deployer: from,
+            deployment_transaction_hash: tx_hash.clone(),
+            deployment_block: block_number.clone(),
+            deployment_timestamp: block_timestamp.clone(),
+            deployer: from.clone(),
             name: Some(name),
             symbol: Some(symbol),
-            decimals: Some(decimals.as_u64()),
+            decimals: Some(decimals.to_u64()),
             total_supply: Some(total_supply.to_string()),
             base_uri: None,
             contract_metadata_uri: None,
@@ -73,10 +75,10 @@ pub fn get_token(
             chain_id: 1.to_string(),
             token_address: token_address.clone(),
             token_type: 3,
-            deployment_transaction_hash: tx_hash,
-            deployment_block: block_number,
-            deployment_timestamp: block_timestamp,
-            deployer: from,
+            deployment_transaction_hash: tx_hash.clone(),
+            deployment_block: block_number.clone(),
+            deployment_timestamp: block_timestamp.clone(),
+            deployer: from.clone(),
             name: None,
             symbol: None,
             decimals: None,
@@ -114,10 +116,10 @@ pub fn get_token(
             chain_id: 1.to_string(),
             token_address: token_address.clone(),
             token_type: 2,
-            deployment_transaction_hash: tx_hash,
-            deployment_block: block_number,
-            deployment_timestamp: block_timestamp,
-            deployer: from,
+            deployment_transaction_hash: tx_hash.clone(),
+            deployment_block: block_number.clone(),
+            deployment_timestamp: block_timestamp.clone(),
+            deployer: from.clone(),
             name: name_res,
             symbol: symbol_res,
             decimals: None,

--- a/token-tracker/src/lib.rs
+++ b/token-tracker/src/lib.rs
@@ -11,27 +11,30 @@ use substreams_ethereum::pb::eth::v2 as eth;
 fn block_to_tokens(blk: eth::Block) -> Result<token_tracker::Tokens, substreams::errors::Error> {
     let mut tokens = token_tracker::Tokens { tokens: vec![] };
 
-    
-    let block_number = blk.clone().number.to_string();
-    let block_timestamp = blk.clone().header.unwrap().timestamp.unwrap().seconds.to_string();
+    let block_number = blk.number.to_string();
+    let block_timestamp = blk
+        .header
+        .as_ref()
+        .unwrap()
+        .timestamp
+        .as_ref()
+        .unwrap()
+        .seconds
+        .to_string();
+
     for call_view in blk.calls() {
-        let tx_hash = Hex(call_view.transaction.clone().hash).to_string();
-        let from = Hex(call_view.transaction.from.clone()).to_string();
+        let tx_hash = Hex(&call_view.transaction.hash).to_string();
+        let from = Hex(&call_view.transaction.from).to_string();
 
         let call = call_view.call;
         if call.call_type == eth::CallType::Create as i32 {
-            let address = Hex(call.address.clone()).to_string();
+            let address = Hex(&call.address).to_string();
 
             log::info!("address {}", address);
 
-            let token = helper::get_token(
-                address,
-                block_number.clone(),
-                block_timestamp.clone(),
-                tx_hash,
-                from
-            );
-            if  token.is_some(){
+            let token =
+                helper::get_token(&address, &block_number, &block_timestamp, &tx_hash, &from);
+            if token.is_some() {
                 tokens.tokens.push(token.unwrap());
             }
         }

--- a/token-tracker/src/pb/mod.rs
+++ b/token-tracker/src/pb/mod.rs
@@ -1,1 +1,2 @@
+#[allow(dead_code)]
 pub mod token_tracker;


### PR DESCRIPTION
Try to avoid clone on nested structure, `blk.clone()` for example is a direct lost as you will be cloning the full block structure which will take a good amount of time while it's not necessary.

I also bump your substreams dependencies to latest version and update some best practices around the project. Note that I only did `token-tracker`.